### PR TITLE
qs static eval adjustment

### DIFF
--- a/include/thread_worker.h
+++ b/include/thread_worker.h
@@ -64,7 +64,8 @@ struct thread_worker{
 
     auto orderer = move_orderer(move_orderer_data{move::null(), move::null(), move::null(), &bd, list, &hh_.us(bd.turn())});
     
-    if(const std::optional<transposition_table_entry> maybe = tt_ -> find(bd.hash()); maybe.has_value()){
+    const std::optional<transposition_table_entry> maybe = tt_ -> find(bd.hash());
+    if(maybe.has_value()){
       const transposition_table_entry entry = maybe.value();
       const bool is_cutoff = 
         (entry.score() >= beta && entry.bound() == bound_type::lower) ||

--- a/include/thread_worker.h
+++ b/include/thread_worker.h
@@ -73,7 +73,15 @@ struct thread_worker{
       orderer.set_first(entry.best_move());
     }
 
-    const search::score_type static_eval = is_check ? ss.effective_mate_score() : eval.evaluate(bd.turn());
+    const search::score_type static_eval = [&]{
+      const search::score_type val = is_check ? ss.effective_mate_score() : eval.evaluate(bd.turn());
+      if(maybe.has_value()){
+        if(maybe -> bound() == bound_type::upper && val > maybe -> score()){ return maybe -> score(); }
+        if(maybe -> bound() == bound_type::lower && val < maybe -> score()){ return maybe -> score(); }
+      }
+      return val;
+    }();
+
     if(list.size() == 0 || static_eval >= beta){ return static_eval; }
     if(ss.reached_max_height()){ return static_eval; }
     


### PR DESCRIPTION
bench: 3855698
ELO   | 12.47 +- 7.11 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4460 W: 1166 L: 1006 D: 2288
ELO   | 18.34 +- 8.26 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2655 W: 589 L: 449 D: 1617