### PR TITLE
support macos

### DIFF
--- a/build/makefile-clang
+++ b/build/makefile-clang
@@ -12,7 +12,19 @@ INCBIN = ../incbin
 SYZYGY = ../syzygy
 
 CXXFLAGS += -std=c++$(CXXSTANDARD)
-CXXFLAGS += -O3 -g -DNDEBUG -march=native -mtune=native -fopenmp
+CXXFLAGS += -O3 -g -DNDEBUG
+
+OS_SPECIFIC = -march=native -mtune=native -fopenmp
+
+ifneq ($(OS),Windows_NT)
+	UNAME_S := $(shell uname -s)
+endif
+
+ifeq ($(UNAME_S),Darwin)
+	OS_SPECIFIC = -mcpu=apple-a14 -DMAC_OS
+endif
+
+CXXFLAGS += $(OS_SPECIFIC)
 CXXFLAGS += -Wall -Wextra -Wpedantic
 CXXFLAGS += -fconstexpr-steps=$(OPSLIMIT)
 CXXFLAGS += -I$(INCLUDE) -I$(INCBIN) -I$(SYZYGY)

--- a/include/simd.h
+++ b/include/simd.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
+#if !defined(MAC_OS)
 #include <x86intrin.h>
+#endif // MACOS
 
 #include <cstdint>
 #include <cstdlib>


### PR DESCRIPTION
hi,

some small changes to the makefile and your simd code to support macos.
`march=native` is not yet fully supported and the header doesnt work for macos

`4599547 nodes 907208 nps` bench output on m1